### PR TITLE
fix: Ensure copy buttons are present on chat reload

### DIFF
--- a/local-llm-chat/frontend/src/app.js
+++ b/local-llm-chat/frontend/src/app.js
@@ -449,7 +449,10 @@ document.addEventListener('DOMContentLoaded', () => {
             addMessageToChatWindow(message.role, message.content);
         });
         if (typeof hljs !== 'undefined') {
-            hljs.highlightAll();
+            chatWindow.querySelectorAll('pre code').forEach((block) => {
+                hljs.highlightElement(block);
+            });
+            addCopyButtonsToCodeBlocks(chatWindow);
         } else {
             runtime.LogError("ERROR: hljs.highlightAll() called in renderMessages but hljs is not defined.");
         }
@@ -489,6 +492,9 @@ document.addEventListener('DOMContentLoaded', () => {
         }
 
         chatWindow.appendChild(messageElement);
+        if (sender === 'assistant') {
+            addCopyButtonsToCodeBlocks(messageElement);
+        }
         chatWindow.scrollTop = chatWindow.scrollHeight;
         return messageElement;
     }
@@ -705,12 +711,43 @@ document.addEventListener('DOMContentLoaded', () => {
         });
 
         if (typeof hljs !== 'undefined') {
-            hljs.highlightAll();
+            lastMessageBubble.querySelectorAll('pre code').forEach((block) => {
+                hljs.highlightElement(block);
+            });
+            addCopyButtonsToCodeBlocks(lastMessageBubble);
         } else {
             console.warn("highlight.js not available, code blocks will not be highlighted.");
         }
 
         scrollToBottom();
+    }
+
+    function addCopyButtonsToCodeBlocks(container) {
+        container.querySelectorAll('pre').forEach(preElement => {
+            if (preElement.parentNode.classList.contains('code-block-wrapper')) {
+                return;
+            }
+
+            const wrapper = document.createElement('div');
+            wrapper.classList.add('code-block-wrapper');
+            preElement.parentNode.insertBefore(wrapper, preElement);
+            wrapper.appendChild(preElement);
+
+            const copyButton = document.createElement('button');
+            copyButton.classList.add('copy-code-button');
+            copyButton.textContent = 'Copy';
+            wrapper.appendChild(copyButton);
+
+            copyButton.addEventListener('click', () => {
+                const codeToCopy = preElement.textContent;
+                runtime.ClipboardSetText(codeToCopy).then(() => {
+                    copyButton.textContent = 'Copied!';
+                    setTimeout(() => {
+                        copyButton.textContent = 'Copy';
+                    }, 2000);
+                });
+            });
+        });
     }
 
     function scrollToBottom() {


### PR DESCRIPTION
This commit fixes an issue where the copy buttons for code blocks would disappear when a chat session was reloaded.

The logic for adding the copy button has been moved to a new reusable function, `addCopyButtonsToCodeBlocks`. This function is now called from `addMessageToChatWindow` and `renderMessages` to ensure that the copy buttons are always present, both for new messages and for messages loaded from the database.