### PR TITLE
Refactor: Make LLM shutdown cross-platform compatible

### DIFF
--- a/local-llm-chat/app_nonwindows.go
+++ b/local-llm-chat/app_nonwindows.go
@@ -13,3 +13,14 @@ func setHideWindow(cmd *exec.Cmd) {
 	}
 	cmd.SysProcAttr.Setpgid = true
 }
+
+func shutdownLLM(cmd *exec.Cmd) error {
+	if cmd != nil && cmd.Process != nil {
+		// On non-windows system we can kill the whole process group by sending a signal to -PID
+		pid := cmd.Process.Pid
+		if err := syscall.Kill(-pid, syscall.SIGTERM); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/local-llm-chat/app_windows.go
+++ b/local-llm-chat/app_windows.go
@@ -2,10 +2,25 @@
 package main
 
 import (
+	"fmt"
 	"os/exec"
+	"strconv"
 	"syscall"
 )
 
 func setHideWindow(cmd *exec.Cmd) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
+}
+
+func shutdownLLM(cmd *exec.Cmd) error {
+	if cmd != nil && cmd.Process != nil {
+		// On windows we can kill the whole process tree using taskkill
+		pid := cmd.Process.Pid
+		kill := exec.Command("taskkill", "/T", "/F", "/PID", strconv.Itoa(pid))
+		err := kill.Run()
+		if err != nil {
+			return fmt.Errorf("failed to kill process tree: %w", err)
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
The previous implementation of the LLM shutdown sequence used `syscall.Kill`, which is a Linux-specific function. This broke the cross-platform compatibility of the application, causing build failures on Windows.

This commit refactors the shutdown logic to be cross-platform compatible. The platform-specific code has been moved into `app_windows.go` and `app_nonwindows.go`, and the main `app.go` file now calls the appropriate function based on the build target.

On Windows, the application now uses the `taskkill` command to terminate the process tree. On non-Windows systems, it continues to use `syscall.Kill` to terminate the process group.