### PR TITLE
Refactor: Relocate UI buttons

### DIFF
--- a/local-llm-chat/frontend/index.html
+++ b/local-llm-chat/frontend/index.html
@@ -27,8 +27,6 @@
 <body>
     <div class="settings-toggle-container">
         <button id="settingsToggleButton" title="Toggle Settings Pane">⚙️</button>
-        <button id="mcpManagerButton" title="MCP Manager">🌐</button>
-        <button id="toggleLogViewButton" title="Toggle Log View">📜</button>
     </div>
     <div class="container">
         <div class="sidebar-container">
@@ -59,6 +57,10 @@
         <div class="artifacts-panel" id="artifactsPanel">
             <div class="resize-handle"></div> <div class="artifacts-header">
                 <h3>Artifacts</h3>
+                <div class="artifact-actions">
+                    <button id="mcpManagerButton" title="MCP Manager">🌐</button>
+                    <button id="toggleLogViewButton" title="Toggle Log View">📜</button>
+                </div>
                 <button id="toggleArtifactsPanel">Toggle</button>
             </div>
             <div class="artifacts-content" id="artifactsContent">

--- a/local-llm-chat/frontend/src/style.css
+++ b/local-llm-chat/frontend/src/style.css
@@ -883,8 +883,8 @@ body {
 /* Settings Toggle Button */
 .settings-toggle-container {
     position: fixed;
-    bottom: 15px; /* Adjusted for a bit more space from the bottom */
-    right: 15px; /* Adjusted for a bit more space from the right */
+    bottom: 1rem;
+    right: 1rem;
     z-index: 1070; /* Increased to be above the artifacts panel */
 }
 
@@ -999,6 +999,13 @@ body {
     color: var(--text-primary);
 }
 
+.artifact-actions {
+    display: flex;
+    gap: 0.5rem;
+    margin-left: auto; /* Pushes the action buttons to the right */
+    padding: 0 10px;
+}
+
 #toggleArtifactsPanel {
     background-color: var(--button-bg);
     color: var(--button-text);
@@ -1062,7 +1069,8 @@ body {
 }
 
 .artifacts-panel.collapsed .artifacts-content,
-.artifacts-panel.collapsed .artifacts-header h3 {
+.artifacts-panel.collapsed .artifacts-header h3,
+.artifacts-panel.collapsed .artifact-actions {
     display: none; /* Hide content and title when collapsed */
 }
 


### PR DESCRIPTION
- Moves the MCP Manager and Toggle Log View buttons into the artifacts panel header.
- This makes these buttons part of the artifacts panel, so they are hidden when the panel is closed.
- Moves the Settings (gear) icon to the bottom-right of the screen and ensures it is always visible.
- Adds styling to support the new button locations.