### PR TITLE
feat: Add GitHub Actions workflow for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,126 @@
+name: Release
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build-linux:
+    name: Build for Linux
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: '1.21'
+
+      - name: Set up Wails
+        run: go install github.com/wailsapp/wails/v2/cmd/wails@latest
+
+      - name: Build application
+        run: |
+          cd local-llm-chat
+          wails build -tags webkit2_41 -o local-llm-chat-linux
+
+      - name: Prepare release assets
+        run: |
+          cd local-llm-chat/build/bin
+          mkdir release
+          mv local-llm-chat-linux release/
+          cp -r ../../prompts release/
+          cp ../../mcp.json release/
+          cd release
+          tar -czvf ../../../../local-llm-chat-linux.tar.gz .
+
+      - name: Upload release asset
+        uses: actions/upload-release-asset@v1
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./local-llm-chat-linux.tar.gz
+          asset_name: local-llm-chat-linux.tar.gz
+          asset_content_type: application/gzip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build-windows:
+    name: Build for Windows
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: '1.21'
+
+      - name: Set up Wails
+        run: go install github.com/wailsapp/wails/v2/cmd/wails@latest
+
+      - name: Build application
+        run: |
+          cd local-llm-chat
+          wails build -o local-llm-chat-windows.exe
+
+      - name: Prepare release assets
+        run: |
+          cd local-llm-chat/build/bin
+          mkdir release
+          move local-llm-chat-windows.exe release/
+          robocopy ..\..\prompts release\prompts /E
+          copy ..\..\mcp.json release\mcp.json
+          cd release
+          powershell -Command "Compress-Archive -Path * -DestinationPath ..\..\..\..\local-llm-chat-windows.zip"
+
+      - name: Upload release asset
+        uses: actions/upload-release-asset@v1
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./local-llm-chat-windows.zip
+          asset_name: local-llm-chat-windows.zip
+          asset_content_type: application/zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build-macos:
+    name: Build for macOS
+    runs-on: macos-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: '1.21'
+
+      - name: Set up Wails
+        run: go install github.com/wailsapp/wails/v2/cmd/wails@latest
+
+      - name: Build application
+        run: |
+          cd local-llm-chat
+          wails build -o "local-llm-chat"
+
+      - name: Prepare release assets
+        run: |
+          cd local-llm-chat/build/bin
+          mkdir release
+          mv "local-llm-chat.app" release/
+          cp -r ../../prompts release/
+          cp ../../mcp.json release/
+          cd release
+          zip -r ../../../../local-llm-chat-macos.zip .
+
+      - name: Upload release asset
+        uses: actions/upload-release-asset@v1
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./local-llm-chat-macos.zip
+          asset_name: local-llm-chat-macos.zip
+          asset_content_type: application/zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This commit introduces a new GitHub Actions workflow to automate the creation of releases. The workflow is triggered when a new release is created in the GitHub repository.

The workflow includes jobs for building the application on Linux, Windows, and macOS. For each platform, the workflow will:
- Set up the build environment.
- Build the Wails application with the correct flags.
- Package the application along with the `prompts` directory and `mcp.json` file into an archive.
- Upload the archive as a release asset.

This will make it easier to provide pre-built binaries for users on different operating systems.